### PR TITLE
fix: per deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build && np --no-cleanup --yolo --no-publish"
   },
   "peerDependencies": {
-    "react": "> 18.x"
+    "react": ">= 16.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",


### PR DESCRIPTION
1. 修复 peerDeps 声明
2. `>18.x` 解析为 `>= 19.0.0`，没有这个版本,部分场景会导致 npm 模式 install 死循环